### PR TITLE
Fix Testing section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 ## Testing
 
 ``` bash
-$ composer test
+$ vendor/bin/phpunit
 ```
 
 ## Contributing


### PR DESCRIPTION
The Testing section referred to a non-existing composer script `test`
